### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  IMAGE: ghcr.io/${{ github.repository_owner }}/vladicore-api
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - run: dotnet restore
+      - run: dotnet build --no-restore -c Release
+      - run: dotnet test --no-build -c Release
+
+  docker:
+    needs: build-test
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write   # чтобы закоммитить обновлённый stack.env
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        run: |
+          docker build -t $IMAGE:latest .
+          docker tag $IMAGE:latest $IMAGE:${{ github.sha }}
+          docker push $IMAGE:latest
+          docker push $IMAGE:${{ github.sha }}
+
+      - name: Bump IMAGE_TAG in stack.env to current SHA
+        run: |
+          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${{ github.sha }}/" stack.env
+          git status --porcelain
+      - name: Commit stack.env bump
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(ci): bump IMAGE_TAG -> ${{ github.sha }}"
+          file_pattern: stack.env


### PR DESCRIPTION
## Summary
- add CI workflow for .NET build/test and Docker image publishing

## Testing
- `dotnet test --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68b5d42d1e38833180f2292149df8301