### PR TITLE
ci: ensure ghcr tags use lowercase owner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,11 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set lowercase repository owner
+        run: echo "OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.OWNER_LC }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
@@ -24,4 +27,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/vladicoreapi:latest
+          tags: ghcr.io/${{ env.OWNER_LC }}/vladicoreapi:latest


### PR DESCRIPTION
## Summary
- normalize repository owner to lowercase before tagging/pushing to GHCR

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e9da7648833180067cee38626add