### PR TITLE
Refactor auth flow to use role entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ dotnet test
 
 ## Sample requests
 ```bash
-curl -X POST http://localhost:9000/auth/register -H "Content-Type: application/json" -d '{"email":"a@b.com","password":"Pass123!","fullName":"A"}'
+curl -X POST http://localhost:9000/auth/register -H "Content-Type: application/json" -d '{"email":"a@b.com","password":"Pass123!","username":"A"}'
 curl -X POST http://localhost:9000/auth/login -H "Content-Type: application/json" -d '{"email":"a@b.com","password":"Pass123!"}'
 curl http://localhost:9000/health
 curl http://localhost:9000/ping

--- a/src/VladiCore.Api/Controllers/AuthController.cs
+++ b/src/VladiCore.Api/Controllers/AuthController.cs
@@ -23,7 +23,7 @@ public class AuthController : ControllerBase
     [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status201Created)]
     public async Task<ActionResult<AuthResponse>> Register(RegisterRequest request)
     {
-        var result = await _authService.RegisterAsync(request.Email, request.Password, request.FullName);
+        var result = await _authService.RegisterAsync(request.Email, request.Password, request.Username);
         return Created(string.Empty, new AuthResponse(result.AccessToken, result.RefreshToken));
     }
 
@@ -32,7 +32,7 @@ public class AuthController : ControllerBase
     public async Task<ActionResult<AuthResponse>> Login(LoginRequest request)
     {
         var result = await _authService.LoginAsync(request.Email, request.Password);
-        return Ok(new AuthResponse(result.AccessToken, result.RefreshToken, result.Role.ToString()));
+        return Ok(new AuthResponse(result.AccessToken, result.RefreshToken, result.Role));
     }
 
     [HttpPost("refresh")]

--- a/src/VladiCore.Api/Models/Auth/RegisterRequest.cs
+++ b/src/VladiCore.Api/Models/Auth/RegisterRequest.cs
@@ -1,3 +1,3 @@
 namespace VladiCore.Api.Models.Auth;
 
-public record RegisterRequest(string Email, string Password, string FullName);
+public record RegisterRequest(string Email, string Password, string Username);

--- a/src/VladiCore.Api/Models/Auth/RegisterRequestValidator.cs
+++ b/src/VladiCore.Api/Models/Auth/RegisterRequestValidator.cs
@@ -8,6 +8,6 @@ public class RegisterRequestValidator : AbstractValidator<RegisterRequest>
     {
         RuleFor(x => x.Email).NotEmpty().EmailAddress();
         RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
-        RuleFor(x => x.FullName).NotEmpty();
+        RuleFor(x => x.Username).NotEmpty();
     }
 }

--- a/src/VladiCore.App/Services/AuthResult.cs
+++ b/src/VladiCore.App/Services/AuthResult.cs
@@ -1,5 +1,3 @@
-using VladiCore.Domain.Enums;
-
 namespace VladiCore.App.Services;
 
-public record AuthResult(string AccessToken, string RefreshToken, UserRole Role);
+public record AuthResult(string AccessToken, string RefreshToken, string? Role);

--- a/src/VladiCore.App/Services/IAuthService.cs
+++ b/src/VladiCore.App/Services/IAuthService.cs
@@ -1,10 +1,8 @@
-using VladiCore.Domain.Enums;
-
 namespace VladiCore.App.Services;
 
 public interface IAuthService
 {
-    Task<AuthResult> RegisterAsync(string email, string password, string fullName);
+    Task<AuthResult> RegisterAsync(string email, string password, string username);
     Task<AuthResult> LoginAsync(string email, string password);
     Task<AuthResult> RefreshAsync(string refreshToken);
     Task LogoutAsync(Guid userId);

--- a/src/VladiCore.App/Services/JwtService.cs
+++ b/src/VladiCore.App/Services/JwtService.cs
@@ -23,10 +23,11 @@ public sealed class JwtService : IJwtService
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.Key));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var expires = DateTime.UtcNow.AddMinutes(_options.AccessMinutes);
+        var roleName = user.Role?.Name ?? string.Empty;
         var claims = new[]
         {
             new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
-            new Claim(ClaimTypes.Role, user.Role.ToString())
+            new Claim(ClaimTypes.Role, roleName)
         };
         var token = new JwtSecurityToken(claims: claims, expires: expires, signingCredentials: creds);
         return (new JwtSecurityTokenHandler().WriteToken(token), expires);

--- a/src/VladiCore.Data/AppDbContext.cs
+++ b/src/VladiCore.Data/AppDbContext.cs
@@ -27,10 +27,19 @@ public class AppDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.HasPostgresExtension("citext");
-        modelBuilder.HasPostgresEnum<OrderStatus>();
-        modelBuilder.HasPostgresEnum<PaymentStatus>();
-        modelBuilder.HasPostgresEnum<Currency>();
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+
+        if (Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory")
+        {
+            modelBuilder.Entity<ProductVariant>().Ignore(p => p.Attributes);
+            modelBuilder.Entity<Payment>().Ignore(p => p.Payload);
+        }
+        else
+        {
+            modelBuilder.HasPostgresExtension("citext");
+            modelBuilder.HasPostgresEnum<OrderStatus>();
+            modelBuilder.HasPostgresEnum<PaymentStatus>();
+            modelBuilder.HasPostgresEnum<Currency>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace role enum usage with role entity and return role names
- switch registration to username and handle missing user role
- ensure in-memory testing works by ignoring JSON properties

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b6cecaaa148331823fa7cce9455701