### PR TITLE
Add schema-aware mappings and inventory/cart constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ dotnet ef migrations add InitialCreate -p src/VladiCore.Data -s src/VladiCore.Ap
 dotnet ef database update -p src/VladiCore.Data -s src/VladiCore.Api
 ```
 
+The PostgreSQL connection string must include
+`Include Error Detail=true; Search Path=public,core,catalog,sales,inventory`
+so EF Core can access all schemas.
+
 ## Build
 ```bash
 dotnet build

--- a/src/VladiCore.Api/appsettings.json
+++ b/src/VladiCore.Api/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Postgres": "Host=postgres;Port=5432;Database=shinozaki_db;Username=aichishinozaki;Password=aichishinozaki651"
+    "Postgres": "Host=postgres;Port=5432;Database=shinozaki_db;Username=aichishinozaki;Password=aichishinozaki651;Include Error Detail=true;Search Path=public,core,catalog,sales,inventory"
   },
   "Jwt": {
     "Key": "change_this_ultra_secret_key_32b_min",

--- a/src/VladiCore.Data/Configurations/CartItemConfiguration.cs
+++ b/src/VladiCore.Data/Configurations/CartItemConfiguration.cs
@@ -8,14 +8,34 @@ public class CartItemConfiguration : IEntityTypeConfiguration<CartItem>
 {
     public void Configure(EntityTypeBuilder<CartItem> builder)
     {
-        builder.ToTable("cart_items");
+        builder.ToTable("cart_items", "sales");
         builder.HasKey(i => i.Id);
         builder.Property(i => i.UnitPrice).HasColumnType("numeric(12,2)");
         builder.Property(i => i.CreatedAt).HasDefaultValueSql("now()");
-        builder.HasCheckConstraint("CK_cartitem_product_variant", "(\"ProductId\" IS NOT NULL)::int + (\"VariantId\" IS NOT NULL)::int = 1");
+
+        builder.HasCheckConstraint("ck_cart_items_xor", "(product_id IS NOT NULL) <> (variant_id IS NOT NULL)");
+
         builder.HasOne(i => i.Cart)
                .WithMany(c => c.Items)
-               .HasForeignKey(i => i.CartId);
-        builder.HasIndex(i => new { i.CartId, i.ProductId, i.VariantId }).IsUnique();
+               .HasForeignKey(i => i.CartId)
+               .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(i => i.Product)
+               .WithMany()
+               .HasForeignKey(i => i.ProductId)
+               .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne(i => i.Variant)
+               .WithMany()
+               .HasForeignKey(i => i.VariantId)
+               .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(i => new { i.CartId, i.ProductId })
+               .IsUnique()
+               .HasFilter("product_id IS NOT NULL");
+
+        builder.HasIndex(i => new { i.CartId, i.VariantId })
+               .IsUnique()
+               .HasFilter("variant_id IS NOT NULL");
     }
 }

--- a/src/VladiCore.Data/Configurations/StockConfiguration.cs
+++ b/src/VladiCore.Data/Configurations/StockConfiguration.cs
@@ -8,15 +8,23 @@ public class StockConfiguration : IEntityTypeConfiguration<Stock>
 {
     public void Configure(EntityTypeBuilder<Stock> builder)
     {
-        builder.ToTable("stock");
+        builder.ToTable("stock", "inventory");
         builder.HasKey(s => s.Id);
         builder.Property(s => s.UpdatedAt).HasDefaultValueSql("now()");
-        builder.HasCheckConstraint("CK_stock_product_variant", "(\"ProductId\" IS NOT NULL)::int + (\"VariantId\" IS NOT NULL)::int = 1");
+
+        builder.HasCheckConstraint("ck_stock_xor", "(product_id IS NOT NULL) <> (variant_id IS NOT NULL)");
+
         builder.HasOne(s => s.Product)
                .WithMany()
-               .HasForeignKey(s => s.ProductId);
+               .HasForeignKey(s => s.ProductId)
+               .OnDelete(DeleteBehavior.Cascade);
+
         builder.HasOne(s => s.Variant)
                .WithMany(v => v.Stocks)
-               .HasForeignKey(s => s.VariantId);
+               .HasForeignKey(s => s.VariantId)
+               .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(s => s.ProductId);
+        builder.HasIndex(s => s.VariantId);
     }
 }

--- a/src/VladiCore.Data/Configurations/UserAddressConfiguration.cs
+++ b/src/VladiCore.Data/Configurations/UserAddressConfiguration.cs
@@ -8,12 +8,18 @@ public class UserAddressConfiguration : IEntityTypeConfiguration<UserAddress>
 {
     public void Configure(EntityTypeBuilder<UserAddress> builder)
     {
-        builder.ToTable("user_addresses");
+        builder.ToTable("user_addresses", "core");
         builder.HasKey(a => a.Id);
         builder.Property(a => a.CreatedAt).HasDefaultValueSql("now()");
         builder.Property(a => a.UpdatedAt).HasDefaultValueSql("now()");
+
         builder.HasOne(a => a.User)
                .WithMany(u => u.Addresses)
-               .HasForeignKey(a => a.UserId);
+               .HasForeignKey(a => a.UserId)
+               .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(a => a.UserId)
+               .IsUnique()
+               .HasFilter("is_default");
     }
 }


### PR DESCRIPTION
## Summary
- map user addresses, cart items, and stock to their respective schemas
- enforce XOR check constraints and partial unique indexes for cart and stock
- include schema search path in default connection string

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6ed419883319568f26979fbc30b