### PR TITLE
Add configurable CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Example env variable:
 ConnectionStrings__Postgres=Host=postgres;Port=5432;Database=shinozaki_db;Username=aichishinozaki;Password=aichishinozaki651;Include Error Detail=true;Search Path=public,core,catalog,sales,inventory
 ```
 
+To allow requests from any origin:
+
+```
+Cors__AllowedOrigins__0=*
+```
+
+To limit CORS, list allowed origins explicitly:
+
+```
+Cors__AllowedOrigins__0=http://localhost:3000
+Cors__AllowedOrigins__1=https://example.com
+```
+
 
 
 ## Build

--- a/src/VladiCore.Api/appsettings.json
+++ b/src/VladiCore.Api/appsettings.json
@@ -14,6 +14,9 @@
     "AccessMinutes": 30,
     "RefreshDays": 14
   },
+  "Cors": {
+    "AllowedOrigins": ["*"]
+  },
   "RateLimit": {
     "PermitPerMinute": 60
   },

--- a/tests/VladiCore.Api.Tests/CorsTests.cs
+++ b/tests/VladiCore.Api.Tests/CorsTests.cs
@@ -1,0 +1,43 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace VladiCore.Api.Tests;
+
+public class CorsTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public CorsTests(TestApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Get_WhenAnyOriginAllowed_ReturnsWildcardHeader()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ping");
+        request.Headers.Add("Origin", "http://example.com");
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Contains("*", response.Headers.GetValues("Access-Control-Allow-Origin"));
+    }
+
+    [Fact]
+    public async Task Get_WithConfiguredOrigin_ReturnsThatOrigin()
+    {
+        Environment.SetEnvironmentVariable("Cors__AllowedOrigins__0", "http://localhost:3000");
+
+        using var factory = new TestApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/ping");
+        request.Headers.Add("Origin", "http://localhost:3000");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Contains("http://localhost:3000", response.Headers.GetValues("Access-Control-Allow-Origin"));
+
+        Environment.SetEnvironmentVariable("Cors__AllowedOrigins__0", null);
+    }
+}


### PR DESCRIPTION
## Summary
- allow configuring wildcard origins for CORS
- document allowing any origin or limiting to specific hosts
- cover wildcard and explicit CORS behavior with integration tests

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8b1d6a748331b1ac734e54a20329