### PR TITLE
fix: validate JWT signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Example env variable:
 
 ```
 ConnectionStrings__Postgres=Host=postgres;Port=5432;Database=shinozaki_db;Username=aichishinozaki;Password=aichishinozaki651;Include Error Detail=true;Search Path=public,core,catalog,sales,inventory
+JWT_KEY=change_this_ultra_secret_key_32b_min
 ```
 
 To allow requests from any origin:

--- a/src/VladiCore.Api/Program.cs
+++ b/src/VladiCore.Api/Program.cs
@@ -34,7 +34,11 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(o =>
     {
-        var key = Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!);
+        var keyString = builder.Configuration["Jwt:Key"];
+        if (string.IsNullOrWhiteSpace(keyString))
+            throw new InvalidOperationException("JWT signing key is not configured.");
+
+        var key = Encoding.UTF8.GetBytes(keyString);
         o.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = false,

--- a/tests/VladiCore.Api.Tests/TestApplicationFactory.cs
+++ b/tests/VladiCore.Api.Tests/TestApplicationFactory.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
 using System.Linq;
 using VladiCore.Data;
 
@@ -12,6 +14,13 @@ public class TestApplicationFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration(cfg =>
+        {
+            cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Key"] = "test_signing_key_1234567890123456789012345"
+            });
+        });
         builder.ConfigureServices(services =>
         {
             var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));


### PR DESCRIPTION
## Summary
- fail fast when JWT signing key is missing
- provide JWT key for test host
- document JWT_KEY environment variable

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ba97d8e8588331bbf9b3bb73f66767