### PR TITLE
refactor: rename jwt key env variable

### DIFF
--- a/stack.env
+++ b/stack.env
@@ -1,6 +1,6 @@
 # первый деплой можно оставить latest, дальше CI будет писать SHA
 IMAGE_TAG=e6f1df43f3da67e293bb8f0b861827e92eb23a9d
-Jwt__Key=5n6X6HHlrHxh2RpzkpAo/JrlI5a/onVxt3R8zcWbRRQ=
+JWT_KEY=5n6X6HHlrHxh2RpzkpAo/JrlI5a/onVxt3R8zcWbRRQ=
 ConnectionStrings__Postgres=Host=postgres;Port=5432;Database=shinozaki_db;Username=aichishinozaki;Password=aichishinozaki651;Include Error Detail=true;Search Path=public,core,catalog,sales,inventory
 Cors__AllowedOrigins__0=*
 


### PR DESCRIPTION
## Summary
- rename stack env variable to `JWT_KEY`

## Testing
- `dotnet test`
- `docker-compose --version` *(fails: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68bae1f579f883319d325f4fc3362ce4