### PR TITLE
fix: load JWT key from legacy env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Example env variable:
 
 ```
 ConnectionStrings__Postgres=Host=postgres;Port=5432;Database=shinozaki_db;Username=aichishinozaki;Password=aichishinozaki651;Include Error Detail=true;Search Path=public,core,catalog,sales,inventory
-JWT_KEY=change_this_ultra_secret_key_32b_min
+Jwt__Key=change_this_ultra_secret_key_32b_min
+
 ```
+
+JWT_KEY is also supported for backward compatibility.
 
 To allow requests from any origin:
 

--- a/src/VladiCore.Api/Program.cs
+++ b/src/VladiCore.Api/Program.cs
@@ -22,6 +22,11 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddFluentValidationAutoValidation();
+
+var legacyJwtKey = builder.Configuration["JWT_KEY"];
+if (!string.IsNullOrWhiteSpace(legacyJwtKey) && string.IsNullOrWhiteSpace(builder.Configuration["Jwt:Key"]))
+    builder.Configuration["Jwt:Key"] = legacyJwtKey;
+
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("Jwt"));
 builder.Services.AddScoped<IPasswordHasher, Pbkdf2PasswordHasher>();
 builder.Services.AddScoped<IJwtService, JwtService>();


### PR DESCRIPTION
## Summary
- map legacy JWT_KEY env var to Jwt:Key for compatibility
- document recommended Jwt__Key setting

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic | tail -n 20`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bae6550ccc8331aca41673dd93d47e