### PR TITLE
Enforce JWT auth with public endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Backend API for VladiCore built with .NET 8.
 
+## Authentication
+Most endpoints require a valid JWT bearer token. The following endpoints are publicly accessible:
+
+- `GET /health`
+- `GET /ping`
+- `GET /api/products` and `GET /api/products/{id}`
+- `GET /api/categories` and `GET /api/categories/{id}`
+- `POST /auth/register`
+- `POST /auth/login`
+- `POST /auth/refresh`
+
+All other endpoints require an `Authorization: Bearer <token>` header.
+
 ## Setup
 Install EF Core CLI:
 ```bash

--- a/src/VladiCore.Api/Controllers/AuthController.cs
+++ b/src/VladiCore.Api/Controllers/AuthController.cs
@@ -21,6 +21,7 @@ public class AuthController : ControllerBase
 
     [HttpPost("register")]
     [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status201Created)]
+    [AllowAnonymous]
     public async Task<ActionResult<AuthResponse>> Register(RegisterRequest request)
     {
         var result = await _authService.RegisterAsync(request.Email, request.Password, request.Username);
@@ -29,6 +30,7 @@ public class AuthController : ControllerBase
 
     [HttpPost("login")]
     [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status200OK)]
+    [AllowAnonymous]
     public async Task<ActionResult<AuthResponse>> Login(LoginRequest request)
     {
         var result = await _authService.LoginAsync(request.Email, request.Password);
@@ -37,6 +39,7 @@ public class AuthController : ControllerBase
 
     [HttpPost("refresh")]
     [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status200OK)]
+    [AllowAnonymous]
     public async Task<ActionResult<AuthResponse>> Refresh(RefreshRequest request)
     {
         var result = await _authService.RefreshAsync(request.RefreshToken);

--- a/src/VladiCore.Api/Controllers/CategoriesController.cs
+++ b/src/VladiCore.Api/Controllers/CategoriesController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using VladiCore.Api.Models.Catalog;
 using VladiCore.Data;
@@ -14,6 +15,7 @@ public class CategoriesController : ControllerBase
     public CategoriesController(AppDbContext db) => _db = db;
 
     [HttpGet]
+    [AllowAnonymous]
     public async Task<ActionResult<IEnumerable<CategoryDto>>> Get()
     {
         var items = await _db.Categories
@@ -23,6 +25,7 @@ public class CategoriesController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     public async Task<ActionResult<CategoryDto>> Get(Guid id)
     {
         var c = await _db.Categories.FindAsync(id);

--- a/src/VladiCore.Api/Controllers/PingController.cs
+++ b/src/VladiCore.Api/Controllers/PingController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace VladiCore.Api.Controllers;
 
 [ApiController]
 [Route("ping")]
+[AllowAnonymous]
 public class PingController : ControllerBase
 {
     [HttpGet]

--- a/src/VladiCore.Api/Controllers/ProductsController.cs
+++ b/src/VladiCore.Api/Controllers/ProductsController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using VladiCore.Api.Models.Catalog;
 using VladiCore.Data;
@@ -15,6 +16,7 @@ public class ProductsController : ControllerBase
     public ProductsController(AppDbContext db) => _db = db;
 
     [HttpGet]
+    [AllowAnonymous]
     public async Task<ActionResult<IEnumerable<ProductDto>>> Get()
     {
         var items = await _db.Products
@@ -24,6 +26,7 @@ public class ProductsController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
+    [AllowAnonymous]
     public async Task<ActionResult<ProductDto>> Get(Guid id)
     {
         var p = await _db.Products.FindAsync(id);

--- a/src/VladiCore.Api/Program.cs
+++ b/src/VladiCore.Api/Program.cs
@@ -12,6 +12,7 @@ using VladiCore.App.Options;
 using VladiCore.App.Services;
 using VladiCore.App;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.AspNetCore.Authorization;
 using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -53,7 +54,10 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(options =>
+    options.FallbackPolicy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build());
 
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>();
 builder.Services.AddCors(options =>
@@ -99,7 +103,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
-app.MapHealthChecks("/health");
+app.MapHealthChecks("/health").AllowAnonymous();
 
 if (!app.Environment.IsEnvironment("Testing"))
 {

--- a/tests/VladiCore.Api.Tests/AnonymousAccessTests.cs
+++ b/tests/VladiCore.Api.Tests/AnonymousAccessTests.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace VladiCore.Api.Tests;
+
+public class AnonymousAccessTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public AnonymousAccessTests(TestApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Get_Products_AllowsAnonymous()
+    {
+        var response = await _client.GetAsync("/api/products");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_Products_RequiresAuthentication()
+    {
+        var response = await _client.PostAsJsonAsync("/api/products", new { });
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_Categories_AllowsAnonymous()
+    {
+        var response = await _client.GetAsync("/api/categories");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_Categories_RequiresAuthentication()
+    {
+        var response = await _client.PostAsJsonAsync("/api/categories", new { });
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- Require authentication by default using fallback policy
- Allow anonymous access to health, ping, product/category GETs, and auth endpoints
- Document authentication rules and add tests for anonymous product/category access

## Testing
- `dotnet format --verbosity normal`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68baebed3a048331b5de5dc38e6c8d52